### PR TITLE
hiding overflow for better appearance on windows

### DIFF
--- a/frontend/src/main.sass
+++ b/frontend/src/main.sass
@@ -1,11 +1,15 @@
 html
   height: 100%
   width: 100%
+  overflow: hidden
 
 body
-  height: 100%
   margin: 0
+  height: 100%
+  width: 100%
+  overflow: hidden
 
 #root
   height: 100%
   width: 100%
+  overflow: hidden


### PR DESCRIPTION
Just set the width and height of #root, body and html to 100% and added overflow: hidden, to prevent appearance of scrollbars.